### PR TITLE
Atualizar para .NET 8, adicionar Serilog e melhorar a segurança

### DIFF
--- a/samples/BaGetWebApplication/BaGetWebApplication.csproj
+++ b/samples/BaGetWebApplication/BaGetWebApplication.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BaGet.Aliyun/BaGet.Aliyun.csproj
+++ b/src/BaGet.Aliyun/BaGet.Aliyun.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <PackageTags>NuGet;Alibaba;Cloud</PackageTags>
     <Description>The libraries to host BaGet on Alibaba Cloud (Aliyun).</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BaGet.Azure/Table/TablePackageDatabase.cs
+++ b/src/BaGet.Azure/Table/TablePackageDatabase.cs
@@ -40,7 +40,7 @@ namespace BaGet.Azure
 
                 await _table.ExecuteAsync(operation, cancellationToken);
             }
-            catch (StorageException e) when (e.IsAlreadyExistsException())
+            catch (StorageException e)  //when (e.IsAlreadyExistsException())
             {
                 return PackageAddResult.PackageAlreadyExists;
             }
@@ -77,7 +77,7 @@ namespace BaGet.Azure
                     return;
                 }
                 catch (StorageException e)
-                    when (attempt < MaxPreconditionFailures && e.IsPreconditionFailedException())
+                    when (attempt < MaxPreconditionFailures) // && e.IsPreconditionFailedException())
                 {
                     attempt++;
                     _logger.LogWarning(
@@ -204,7 +204,7 @@ namespace BaGet.Azure
             {
                 await _table.ExecuteAsync(operation, cancellationToken);
             }
-            catch (StorageException e) when (e.IsNotFoundException())
+            catch (StorageException e) //when (e.IsNotFoundException())
             {
                 return false;
             }

--- a/src/BaGet.Web/BaGet.Web.csproj
+++ b/src/BaGet.Web/BaGet.Web.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <PackageTags>NuGet</PackageTags>
     <Description>BaGet's NuGet server implementation</Description>

--- a/src/BaGet/BaGet.csproj
+++ b/src/BaGet/BaGet.csproj
@@ -1,14 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BouncyCastle.NetCore" Version="2.2.1" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="$(MicrosoftAspNetCorePackageVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="$(MicrosoftEntityFrameworkCorePackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaGet/Program.cs
+++ b/src/BaGet/Program.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using BaGet.Core;
 using BaGet.Web;
@@ -10,7 +12,18 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Operators;
+using Org.BouncyCastle.OpenSsl;
+using Org.BouncyCastle.X509;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Asn1;
+using System.Security.Cryptography;
+using Microsoft.Extensions.Logging;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Security;
+using Serilog;
+using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
 
 /* 
     - Publicando o projeto Nuget Server 
@@ -49,6 +62,7 @@ namespace BaGet
 {
     public class Program
     {
+
         public static async Task Main(string[] args)
         {
             var host = CreateHostBuilder(args).Build();
@@ -94,8 +108,21 @@ namespace BaGet
 
         public static IHostBuilder CreateHostBuilder(string[] args)
         {
+            var logFilePath = Path.Combine(AppContext.BaseDirectory, "logs", "log.txt");
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .WriteTo.Console()  // Write logs to the console
+                .WriteTo.File(logFilePath, rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)  // Write logs to a file
+                .CreateLogger();
+
+
             var host = Host
                 .CreateDefaultBuilder(args)
+                //.ConfigureServices((context, services) =>
+                //{
+                //    services.AddLogging();
+                //})
+                .UseSerilog()
                 .ConfigureAppConfiguration((ctx, config) =>
                 {
                     var root = Environment.GetEnvironmentVariable("BAGET_CONFIG_ROOT");
@@ -105,7 +132,13 @@ namespace BaGet
                         config.SetBasePath(root);
                     }
                 })
-                .ConfigureWebHostDefaults(web =>
+                .ConfigureLogging(logging =>
+                {
+                    logging.ClearProviders();  // Clear other logging providers
+                    // Serilog is already set up, so no need to add Console or File here
+                    logging.SetMinimumLevel(LogLevel.Debug); // Ajuste conforme necessário
+                })
+                .ConfigureWebHostDefaults((web) =>
                 {
                     //web.UseUrls(
                     //    //$"http://*:61437",
@@ -113,7 +146,7 @@ namespace BaGet
                     web
                         //.UseUrls()
                         //.UseKestrel()
-                        .ConfigureKestrel(options =>
+                        .ConfigureKestrel((context, options) =>
                     {
                         var port = 61438;
                         // Remove the upload limit from Kestrel. If needed, an upload limit can
@@ -122,21 +155,105 @@ namespace BaGet
                         //options.ListenAnyIP(61437);
                         options.Listen(IPAddress.Any, port, listenOptions =>
                         {
-                            var certPath = Path.Combine(AppContext.BaseDirectory, "Certificados", "certificate.pfx");
+                            var config = context.Configuration;
+
+                            var certPath = config["Certificado:PathFileCrt"];
+                            var keyPath = config["Certificado:PathFileKey"];
+                            var certPfx = config["Certificado:PathFilePfx"];
+                            var password = config["Certificado:Senha"];
+
+
+
+
+                            //var certPath = Path.Combine(AppContext.BaseDirectory, "Certificados", "nuget.esistem.com.br.pfx");
+                            //var certPath = config.Configuration["Certificado:PathFileCrt"];
                             //////var keyPath = Path.Combine(AppContext.BaseDirectory, "Certificados", "key.pem");
-                            var password = "#eSistem2023@";
+                            //var password = config.Configuration["Certificado:Senha"];//"#eSistem2023@";
                             //var cert = new X509Certificate2(certPath);
                             //var connectionOptions = new HttpsConnectionAdapterOptions();
                             //connectionOptions.ServerCertificate = cert;
-                            listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
-                            listenOptions.UseHttps(certPath,password);
-                        });
-                    });
 
-                    web.UseStartup<Startup>();
+                            if (!string.IsNullOrEmpty(certPath) && !string.IsNullOrEmpty(password) && !string.IsNullOrEmpty(keyPath))
+                            {
+                                var certificate = LoadCertificate(certPath, keyPath, password);
+                                listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
+                                listenOptions.UseHttps(certificate);
+                            }
+                            else if (!string.IsNullOrEmpty(certPfx) && !string.IsNullOrEmpty(password))
+                            {
+                                listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
+                                listenOptions.UseHttps(certPfx, password);
+                            }
+                            else
+                            {
+                                throw new Exception("Certificado não configurado corretamente.");
+                            }
+                        });
+                    }).UseStartup<Startup>();
+
                 });
 
             return host;
+        }
+
+
+        public static X509Certificate2 LoadCertificate(string certPath, string keyPath, string password)
+        {
+            // Leitura do certificado .crt
+            var certPem = File.ReadAllText(certPath);
+
+            // Leitura da chave .key
+            var keyPem = File.ReadAllText(keyPath);
+
+            // Carregar o certificado
+            var certParser = new PemReader(new StringReader(certPem));
+            var cert = (X509Certificate)certParser.ReadObject();
+
+            // Carregar a chave privada
+            var keyParser = new PemReader(new StringReader(keyPem));
+
+            var keyObject = keyParser.ReadObject();
+            RsaPrivateCrtKeyParameters privateKey;
+
+            switch (keyObject)
+            {
+                case AsymmetricCipherKeyPair keyPair:
+                    privateKey = keyPair.Private as RsaPrivateCrtKeyParameters;
+                    break;
+                case RsaPrivateCrtKeyParameters rsaPrivateKey:
+                    privateKey = rsaPrivateKey;
+                    break;
+                default:
+                    throw new InvalidCastException("Unsupported key type.");
+            }
+
+
+            //var keyPair = (AsymmetricCipherKeyPair)keyParser.ReadObject();
+            //var privateKey = keyPair.Private as RsaPrivateCrtKeyParameters;
+
+            // Converter chave para o formato que o X509Certificate2 pode aceitar
+            var rsa = RSA.Create();
+            if (privateKey != null)
+                rsa.ImportParameters(new RSAParameters
+                {
+                    Modulus = privateKey.Modulus.ToByteArrayUnsigned(),
+                    Exponent = privateKey.PublicExponent.ToByteArrayUnsigned(),
+                    P = privateKey.P.ToByteArrayUnsigned(),
+                    Q = privateKey.Q.ToByteArrayUnsigned(),
+                    DP = privateKey.DP.ToByteArrayUnsigned(),
+                    DQ = privateKey.DQ.ToByteArrayUnsigned(),
+                    InverseQ = privateKey.QInv.ToByteArrayUnsigned(),
+                    D = privateKey.Exponent.ToByteArrayUnsigned()
+                });
+
+            // Criar o certificado X509
+            var certBytes = cert.GetEncoded();
+            var certificate = new X509Certificate2(certBytes);
+
+            // Adicionar a chave privada ao certificado
+            var certWithKey = certificate.CopyWithPrivateKey(rsa);
+
+            return certWithKey;
         }
     }
 }

--- a/src/BaGet/Properties/launchSettings.json
+++ b/src/BaGet/Properties/launchSettings.json
@@ -23,7 +23,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation"
       },
-      "applicationUrl": "http://localhost:50561/"
+      "applicationUrl": "https://localhost:61438"
     }
   }
 }

--- a/src/BaGet/appsettings.Development.json
+++ b/src/BaGet/appsettings.Development.json
@@ -24,6 +24,13 @@
     //"Legacy": true,
     "PackageSource": "https://api.nuget.org/v3/index.json"
   },
+  "Certificado": {
+    "PathFileCrt": "",
+    "PathFileKey": "",
+    "PathFilePfx": "D:\\trab\\temp\\Certificados\\localhost\\localhost.pfx",
+    "Senha": "#eSistem2023@"
+  },
+
 
   // Uncomment this to configure BaGet to listen to port 8080.
   // See: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-3.1#listenoptionsusehttps

--- a/src/BaGet/appsettings.json
+++ b/src/BaGet/appsettings.json
@@ -24,7 +24,11 @@
     //"Legacy": true,
     "PackageSource": "https://api.nuget.org/v3/index.json"
   },
-
+  "Certificado": {
+    "PathFileCrt": "D:\\trab\\temp\\Certificados\\nuget.esistem.com.br.crt",
+    "PathFileKey": "D:\\trab\\temp\\Certificados\\nuget.esistem.com.br.key",
+    "Senha": "#eSistem2023@",
+  },
   // Uncomment this to configure BaGet to listen to port 8080.
   // See: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-3.1#listenoptionsusehttps
   //"Kestrel": {

--- a/tests/BaGet.Core.Tests/BaGet.Core.Tests.csproj
+++ b/tests/BaGet.Core.Tests/BaGet.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/BaGet.Protocol.Tests/BaGet.Protocol.Tests.csproj
+++ b/tests/BaGet.Protocol.Tests/BaGet.Protocol.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/BaGet.Tests/BaGet.Tests.csproj
+++ b/tests/BaGet.Tests/BaGet.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 

--- a/tests/BaGet.Web.Tests/BaGet.Web.Tests.csproj
+++ b/tests/BaGet.Web.Tests/BaGet.Web.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Atualizar a estrutura de destino para .NET 8.0 para vários projetos, incluindo BaGetWebApplication, BaGet.Aliyun e outros. Adicionar novas referências de pacote em BaGet.csproj: BouncyCastle.NetCore, Serilog.AspNetCore, Serilog.Sinks.Console e Serilog.Sinks.File.

Aprimorar o registro em Program.cs e Startup.cs usando Serilog, configurar o Kestrel para carregar certificados da configuração e adicionar um método para carregar certificados de arquivos .crt e .key.

Modificar o tratamento de exceções em TablePackageDatabase.cs removendo filtros de exceção específicos. Alterar URL do aplicativo em launchSettings.json para usar HTTPS. Adicionar seções de configuração de certificado em appsettings.json e appsettings.Development.json.

Pequenos ajustes de formatação e espaço em branco em vários arquivos.

Colocado a informação de certificado e senh ano appsetings.json

Summary of the changes (in less than 80 chars)

 * Detail 1
 * Detail 2

Addresses https://github.com/loic-sharma/BaGet/issues/123
